### PR TITLE
Fix token refresh flow

### DIFF
--- a/src/contexts/user-context.tsx
+++ b/src/contexts/user-context.tsx
@@ -32,6 +32,13 @@ export function UserProvider({ children }: UserProviderProps): React.JSX.Element
 
       if (error) {
         logger.error(error);
+
+        if (error === 'Geçersiz veya süresi dolmuş token') {
+          await authClient.signOut();
+          setState((prev) => ({ ...prev, user: null, error: null, isLoading: false }));
+          return;
+        }
+
         setState((prev) => ({ ...prev, user: null, error: 'Something went wrong', isLoading: false }));
         return;
       }

--- a/src/services/axiosClient.ts
+++ b/src/services/axiosClient.ts
@@ -6,15 +6,21 @@ const axiosClient = axios.create({
 });
 
 axiosClient.interceptors.request.use((config) => {
-        const token = typeof window !== 'undefined' ? localStorage.getItem('custom-auth-token') : null;
-
-   
     if (!config.headers) {
         config.headers = {};
     }
-  if (token) {
-        config.headers.Authorization = `Bearer ${token}`;
+
+    const isRefreshEndpoint = config.url?.includes('/auth/refresh');
+
+    if (typeof window !== 'undefined') {
+        const tokenKey = isRefreshEndpoint ? 'custom-refresh-token' : 'custom-auth-token';
+        const token = localStorage.getItem(tokenKey);
+
+        if (token) {
+            config.headers.Authorization = `Bearer ${token}`;
+        }
     }
+
     return config;
 });
 let isRefreshing = false;


### PR DESCRIPTION
## Summary
- include refresh token in axios interceptor
- clear stored tokens on invalid/expired session

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing dependencies)*
- `npm run format:write` *(fails: missing prettier plugin)*

------
https://chatgpt.com/codex/tasks/task_e_683af94bbd2c832c8ac67e35bdd2cfff