### PR TITLE
Add redirect after accepting production request and update invite API

### DIFF
--- a/src/app/auctions/list/page.tsx
+++ b/src/app/auctions/list/page.tsx
@@ -166,21 +166,21 @@ export default function ListAuctionsPage() {
                 setPrLoading(false);
             });
     };
- const handleInviteAction = (auctionId: number, status: 'accepted' | 'rejected') => {
-        if (!userId) return;
+ const handleInviteAction = (inviteId: number, action: 'accepted' | 'declined') => {
         axiosClient
-            .put('/inviteStatus', {
-                user_id: userId,
-                auction_id: auctionId,
-                invite_status: status,
+            .post('/auctions/respondInvite', {
+                inviteId,
+                action,
             })
             .then(() => {
                 setAuctions((prev) =>
-                    prev.map((a) => (a.id === auctionId ? { ...a, invite_status: status } : a))
+                    prev.map((a) =>
+                        a.id === inviteId ? { ...a, invite_status: action } : a
+                    )
                 );
             })
             .catch((err) => {
-                console.error('Error updating invite status:', err);
+                console.error('Error responding to invite:', err);
             });
     };
 
@@ -284,7 +284,7 @@ export default function ListAuctionsPage() {
                                                             variant="outlined"
                                                             color="error"
                                                             size="small"
-                                                            onClick={() => handleInviteAction(item.id, 'rejected')}
+                                                            onClick={() => handleInviteAction(item.id, 'declined')}
                                                         >
                                                             Reject
                                                         </Button>

--- a/src/app/productionRequests/list/page.tsx
+++ b/src/app/productionRequests/list/page.tsx
@@ -24,6 +24,7 @@ import {
 } from '@mui/material';
 import { MagnifyingGlass as MagnifyingGlassIcon } from '@phosphor-icons/react';
 import axiosClient from '@/services/axiosClient';
+import { useRouter } from 'next/navigation';
 
 interface ProductionRequest {
   id: number;
@@ -35,6 +36,7 @@ interface ProductionRequest {
 }
 
 export default function ListProductionRequestsPage() {
+  const router = useRouter();
   const [requests, setRequests] = React.useState<ProductionRequest[]>([]);
   const [page, setPage] = React.useState(0);
   const [rowsPerPage, setRowsPerPage] = React.useState(5);
@@ -99,6 +101,9 @@ export default function ListProductionRequestsPage() {
         setRequests((prev) =>
           prev.map((r) => (r.id === id ? { ...r, status } : r))
         );
+        if (status === 'accepted') {
+          router.push(`/auctions/create/${id}`);
+        }
       })
       .catch((err) => {
         console.error('Error updating production request status:', err);


### PR DESCRIPTION
## Summary
- redirect to create auction page when a production request is accepted
- use new API `/auctions/respondInvite` and support decline

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_686537701230832c8de29019b74a6598