### PR TITLE
Use single logo image sitewide

### DIFF
--- a/src/components/core/logo.tsx
+++ b/src/components/core/logo.tsx
@@ -18,14 +18,9 @@ export interface LogoProps {
   width?: number;
 }
 
-export function Logo({ color = 'dark', emblem, height = HEIGHT, width = WIDTH }: LogoProps): React.JSX.Element {
-  let url: string;
-
-  if (emblem) {
-    url = color === 'light' ? '/assets/logo-emblem.svg' : '/assets/logo-emblem--dark.svg';
-  } else {
-    url = color === 'light' ? '/assets/logo.svg' : '/assets/logo--dark.svg';
-  }
+export function Logo({ height = HEIGHT, width = WIDTH }: LogoProps): React.JSX.Element {
+  // Use a single logo image across the application
+  const url = '/assets/image.png';
 
   return <Box alt="logo" component="img" height={height} src={url} width={width} />;
 }

--- a/src/components/dashboard/layout/mobile-nav.tsx
+++ b/src/components/dashboard/layout/mobile-nav.tsx
@@ -118,7 +118,7 @@ export function MobileNav({ open, onClose }: MobileNavProps): React.JSX.Element 
           <Box
             component="img"
             alt="Pro version"
-            src="/assets/devias-kit-pro.png"
+            src="/assets/image.png"
             sx={{ height: 'auto', width: '160px' }}
           />
         </Box>

--- a/src/components/dashboard/layout/side-nav.tsx
+++ b/src/components/dashboard/layout/side-nav.tsx
@@ -110,7 +110,7 @@ export function SideNav(): React.JSX.Element {
           <Box
             component="img"
             alt=""
-            src="/assets/devias-kit-pro.png"
+            src="/assets/image.png"
             sx={{ height: 'auto', width: '160px' }}
           />
         </Box>


### PR DESCRIPTION
## Summary
- replace all logos with the image located at `/assets/image.png`
- update side and mobile navigation images

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865576d56c0832cbe07f428dee874c4