### PR TITLE
Configure production domains

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+REACT_APP_API_URL=https://api.demaxtore.com
+NEXT_PUBLIC_SITE_URL=https://panel.demaxtore.com
+NEXT_PUBLIC_SOCKET_URL=https://api.demaxtore.com
+NEXT_PUBLIC_LOG_LEVEL=ALL

--- a/src/app/auctions/[id]/page.tsx
+++ b/src/app/auctions/[id]/page.tsx
@@ -358,7 +358,7 @@ setIsActive(now >= start && now <= end);
   //----------------------------------------------------------------
   useEffect(() => {
     if (!auction) return;
-    const SOCKET_URL = process.env.NEXT_PUBLIC_SOCKET_URL || 'https://backendauction.recepaslan.com.tr';
+    const SOCKET_URL = process.env.NEXT_PUBLIC_SOCKET_URL || 'https://api.demaxtore.com';
     const socket = io(SOCKET_URL, { path: '/socket.io' });
     socketRef.current = socket as unknown as typeof Socket;
 

--- a/src/lib/get-site-url.ts
+++ b/src/lib/get-site-url.ts
@@ -2,7 +2,7 @@ export function getSiteURL(): string {
   let url =
     process.env.NEXT_PUBLIC_SITE_URL ?? // Set this to your site URL in production env.
     process.env.NEXT_PUBLIC_VERCEL_URL ?? // Automatically set by Vercel.
-    'localhost:3000/';
+    'panel.demaxtore.com/';
   // Make sure to include `https://` when not localhost.
   url = url.includes('http') ? url : `https://${url}`;
   // Make sure to include a trailing `/`.

--- a/src/services/axiosClient.ts
+++ b/src/services/axiosClient.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const axiosClient = axios.create({
-    baseURL: process.env.REACT_APP_API_URL || 'http://localhost:3000',
+    baseURL: process.env.REACT_APP_API_URL || 'https://api.demaxtore.com',
     headers: { 'Content-Type': 'application/json' }
 });
 


### PR DESCRIPTION
## Summary
- update default API and socket URLs
- default site URL to panel.demaxtore.com
- provide sample env configuration

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68671f5d5644832c8cc4f742ff2c8ff0