### PR TITLE
Handle invalid tokens during auth checks and improve logout UX

### DIFF
--- a/src/components/dashboard/layout/user-popover.tsx
+++ b/src/components/dashboard/layout/user-popover.tsx
@@ -40,9 +40,8 @@ export function UserPopover({ anchorEl, onClose, open }: UserPopoverProps): Reac
       // Refresh the auth state
       await checkSession?.();
 
-      // UserProvider, for this case, will not refresh the router and we need to do it manually
-      router.refresh();
-      // After refresh, AuthGuard will handle the redirect
+      // Navigate to the sign in page
+      router.replace(paths.auth.signIn);
     } catch (err) {
       logger.error('Sign out error', err);
     }

--- a/src/contexts/user-context.tsx
+++ b/src/contexts/user-context.tsx
@@ -33,7 +33,8 @@ export function UserProvider({ children }: UserProviderProps): React.JSX.Element
       if (error) {
         logger.error(error);
 
-        if (error === 'Geçersiz veya süresi dolmuş token') {
+        const tokenError = error.toLowerCase().includes('token');
+        if (tokenError) {
           await authClient.signOut();
           setState((prev) => ({ ...prev, user: null, error: null, isLoading: false }));
           return;


### PR DESCRIPTION
## Summary
- clear storage when an auth token error occurs
- redirect to the sign-in page after logging out

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find module 'react' etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68769afb2dd0832ca4d47d624fd0931a