### PR TITLE
Implement review formatting and success toasts

### DIFF
--- a/src/app/auctions/create/[id]/page.tsx
+++ b/src/app/auctions/create/[id]/page.tsx
@@ -25,7 +25,9 @@ import {
     Checkbox,
     List,
     ListItem,
-    ListItemText
+    ListItemText,
+    Snackbar,
+    Alert
 } from '@mui/material';
 import axiosClient from '@/services/axiosClient';
 const currencyOptions = ['USD', 'EUR', 'TRY', 'GBP'];
@@ -51,6 +53,7 @@ export default function AuctionCreatePage() {
     const [loading, setLoading] = React.useState(false);
     const [errorMessage, setErrorMessage] = React.useState('');
     const [successMessage, setSuccessMessage] = React.useState('');
+    const [toastOpen, setToastOpen] = React.useState(false);
 const handleOpenSuppliers = () => {
         setOpenSuppliers(true);
         if (suppliers.length === 0) {
@@ -110,6 +113,7 @@ const handleOpenSuppliers = () => {
 
             console.log('Auction created:', response.data);
             setSuccessMessage('Auction created successfully!');
+            setToastOpen(true);
             // Reset form
             setTitle('');
             setStartTime('');
@@ -342,6 +346,21 @@ const handleOpenSuppliers = () => {
                     <Button onClick={handleCloseSuppliers}>Close</Button>
                 </DialogActions>
             </Dialog>
+            <Snackbar
+                open={toastOpen}
+                autoHideDuration={3000}
+                onClose={() => setToastOpen(false)}
+                anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+            >
+                <Alert
+                    onClose={() => setToastOpen(false)}
+                    severity="success"
+                    variant="filled"
+                    sx={{ width: '100%' }}
+                >
+                    {successMessage}
+                </Alert>
+            </Snackbar>
         </form>
     );
 }

--- a/src/app/dashboard/productionRequests/create/page.tsx
+++ b/src/app/dashboard/productionRequests/create/page.tsx
@@ -104,6 +104,15 @@ export default function ProductionRequestCreatePage(): React.JSX.Element {
     orderQuantity: '',
   });
 
+  const formatLabel = (label: string) =>
+    label.charAt(0).toUpperCase() + label.slice(1);
+
+  const formatValue = (key: string, value: string) => {
+    if (key === 'gluten') return `${value}%`;
+    if (key === 'protein') return `${value} g`;
+    return value;
+  };
+
   const handleChange = (field: keyof typeof form, value: string) => {
     setForm((prev) => ({ ...prev, [field]: value }));
   };
@@ -289,7 +298,7 @@ export default function ProductionRequestCreatePage(): React.JSX.Element {
                   value={form.protein}
                   onChange={(e) => handleChange('protein', e.target.value)}
                 />
-                <FormHelperText>% value</FormHelperText>
+                <FormHelperText>g value</FormHelperText>
               </FormControl>
             </Grid>
             <Grid xs={12} md={6}>
@@ -452,7 +461,12 @@ export default function ProductionRequestCreatePage(): React.JSX.Element {
             <CardContent>
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
                 {Object.entries(form).map(([key, value]) =>
-                  value ? <Typography key={key}>{`${key}: ${value}`}</Typography> : null
+                  value ? (
+                    <Typography key={key}>{`${formatLabel(key)}: ${formatValue(
+                      key,
+                      value as string
+                    )}`}</Typography>
+                  ) : null
                 )}
                 {errorMessage && <Typography color="error">{errorMessage}</Typography>}
               </Box>

--- a/src/app/payments/create/page.tsx
+++ b/src/app/payments/create/page.tsx
@@ -15,7 +15,9 @@ import {
     OutlinedInput,
     Select,
     MenuItem,
-    Typography
+    Typography,
+    Snackbar,
+    Alert
 } from '@mui/material';
 import axiosClient from '@/services/axiosClient';
 
@@ -31,6 +33,7 @@ export default function CreatePaymentSchedulePage() {
     const [loading, setLoading] = React.useState(false);
     const [errorMessage, setErrorMessage] = React.useState('');
     const [successMessage, setSuccessMessage] = React.useState('');
+    const [toastOpen, setToastOpen] = React.useState(false);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -51,6 +54,7 @@ export default function CreatePaymentSchedulePage() {
 
             console.log('Payment schedule created:', resp.data);
             setSuccessMessage('Payment schedule created successfully!');
+            setToastOpen(true);
             setOrderId('');
             setPaymentType('partial');
             setAmount('');
@@ -176,6 +180,16 @@ export default function CreatePaymentSchedulePage() {
                     </Button>
                 </CardActions>
             </Card>
+            <Snackbar
+                open={toastOpen}
+                autoHideDuration={3000}
+                onClose={() => setToastOpen(false)}
+                anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+            >
+                <Alert onClose={() => setToastOpen(false)} severity="success" variant="filled" sx={{ width: '100%' }}>
+                    {successMessage}
+                </Alert>
+            </Snackbar>
         </form>
     );
 }

--- a/src/app/productionRequests/create/page.tsx
+++ b/src/app/productionRequests/create/page.tsx
@@ -103,6 +103,15 @@ export default function ProductionRequestCreatePage(): React.JSX.Element {
     orderQuantity: '',
   });
 
+  const formatLabel = (label: string) =>
+    label.charAt(0).toUpperCase() + label.slice(1);
+
+  const formatValue = (key: string, value: string) => {
+    if (key === 'gluten') return `${value}%`;
+    if (key === 'protein') return `${value} g`;
+    return value;
+  };
+
   const handleChange = (field: keyof typeof form, value: string) => {
     setForm((prev) => ({ ...prev, [field]: value }));
   };
@@ -287,7 +296,7 @@ export default function ProductionRequestCreatePage(): React.JSX.Element {
                   value={form.protein}
                   onChange={(e) => handleChange('protein', e.target.value)}
                 />
-                <FormHelperText>% value</FormHelperText>
+                <FormHelperText>g value</FormHelperText>
               </FormControl>
             </Grid>
             <Grid xs={12} md={6}>
@@ -437,7 +446,12 @@ export default function ProductionRequestCreatePage(): React.JSX.Element {
             <CardContent>
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
                 {Object.entries(form).map(([key, value]) =>
-                  value ? <Typography key={key}>{`${key}: ${value}`}</Typography> : null
+                  value ? (
+                    <Typography key={key}>{`${formatLabel(key)}: ${formatValue(
+                      key,
+                      value as string
+                    )}`}</Typography>
+                  ) : null
                 )}
                 {errorMessage && <Typography color="error">{errorMessage}</Typography>}
               </Box>

--- a/src/app/shipments/create/page.tsx
+++ b/src/app/shipments/create/page.tsx
@@ -15,7 +15,9 @@ import {
     OutlinedInput,
     Select,
     MenuItem,
-    Typography
+    Typography,
+    Snackbar,
+    Alert
 } from '@mui/material';
 import axiosClient from '@/services/axiosClient';
 
@@ -32,6 +34,7 @@ export default function CreateShipmentPage() {
     const [loading, setLoading] = React.useState(false);
     const [errorMessage, setErrorMessage] = React.useState('');
     const [successMessage, setSuccessMessage] = React.useState('');
+    const [toastOpen, setToastOpen] = React.useState(false);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -53,6 +56,7 @@ export default function CreateShipmentPage() {
 
             console.log('Shipment created:', resp.data);
             setSuccessMessage('Shipment created successfully!');
+            setToastOpen(true);
             setOrderId('');
             setShipmentType('sea');
             setContainerNo('');
@@ -186,6 +190,16 @@ export default function CreateShipmentPage() {
                     </Button>
                 </CardActions>
             </Card>
+            <Snackbar
+                open={toastOpen}
+                autoHideDuration={3000}
+                onClose={() => setToastOpen(false)}
+                anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+            >
+                <Alert onClose={() => setToastOpen(false)} severity="success" variant="filled" sx={{ width: '100%' }}>
+                    {successMessage}
+                </Alert>
+            </Snackbar>
         </form>
     );
 }


### PR DESCRIPTION
## Summary
- show formatted key/value pairs in production request reviews
- display gluten in percent and protein in grams
- trigger success toast for auction, payment, and shipment creation
- show success toast using Snackbar and Alert

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68769d3911d4832c8d2943347221c140